### PR TITLE
Associations

### DIFF
--- a/app/assets/javascripts/listings.js
+++ b/app/assets/javascripts/listings.js
@@ -147,7 +147,7 @@ $(function(){
   });
 
   function searchEscape(value) {
-    if (value == /\w+/) {
+    if (value.toString().indexOf(" ") == -1) {
       return value;
     } else if (value.indexOf("'") > -1) {
       return '"' + value + '"';

--- a/app/views/listings/_filters.html.haml
+++ b/app/views/listings/_filters.html.haml
@@ -6,6 +6,6 @@
       - filter_view.values.each do |value|
         %li.filter
           %a{:href => '#', :'data-key' => filter_view.key, :'data-value' => value}
-            = value
+            = filter_view.value_for(value)
             %i.icon-remove
 

--- a/app/views/listings/_filters.html.haml
+++ b/app/views/listings/_filters.html.haml
@@ -2,7 +2,7 @@
   - listing.filters.each do |filter_view|
     %ul.nav.nav-list.well
       %li.nav-header
-        = "Filter by #{filter_view.key}"
+        = "Filter by #{filter_view.human_name}"
       - filter_view.values.each do |value|
         %li.filter
           %a{:href => '#', :'data-key' => filter_view.key, :'data-value' => value}

--- a/app/views/listings/_filters.html.haml
+++ b/app/views/listings/_filters.html.haml
@@ -1,11 +1,11 @@
 .filters
-  - listing.filter_values.each do |k,v|
+  - listing.filters.each do |filter_view|
     %ul.nav.nav-list.well
       %li.nav-header
-        = "Filter by #{k}"
-      - v.each do |x|
+        = "Filter by #{filter_view.key}"
+      - filter_view.values.each do |value|
         %li.filter
-          %a{:href => '#', :'data-key' => k, :'data-value' => x}
-            = x
+          %a{:href => '#', :'data-key' => filter_view.key, :'data-value' => value}
+            = value
             %i.icon-remove
 

--- a/app/views/listings/_table_content.html.haml
+++ b/app/views/listings/_table_content.html.haml
@@ -9,7 +9,7 @@
         - listing.columns.each do |col|
           %th{'class' => "#{'sortable ' + (col.sort || '') if col.sortable?}" }
             - if col.sortable?
-              = link_to col.human_name, listing.url_for_sort(col.name, col.next_sort_direction), remote: true
+              = link_to col.human_name, listing.url_for_sort(col.key, col.next_sort_direction), remote: true
             - else
               = col.human_name
 

--- a/lib/listings.rb
+++ b/lib/listings.rb
@@ -1,5 +1,6 @@
 require 'kaminari'
 require 'bootstrap-kaminari-views'
+require 'listings/sources'
 require 'listings/configuration'
 require 'listings/kaminari_helpers_tag_patch'
 require 'listings/base'

--- a/lib/listings/base.rb
+++ b/lib/listings/base.rb
@@ -151,6 +151,10 @@ module Listings
       self.filters.find { |c| c.key == key }
     end
 
+    def human_name(field)
+      field.human_name
+    end
+
     def searchable?
       self.columns.any? &:searchable?
     end

--- a/lib/listings/base.rb
+++ b/lib/listings/base.rb
@@ -97,7 +97,7 @@ module Listings
       end
 
       if params.include?(param_sort_by)
-        sort_col = column_with_name(params[param_sort_by])
+        sort_col = column_with_key(params[param_sort_by])
         sort_col.sort = params[param_sort_direction]
         data_source.sort(sort_col.field, params[param_sort_direction])
       end
@@ -143,8 +143,8 @@ module Listings
       column.value_for(self, item)
     end
 
-    def column_with_name(name)
-      self.columns.find { |c| c.name.to_s == name.to_s }
+    def column_with_key(key)
+      self.columns.find { |c| c.key == key }
     end
 
     def filter_with_key(key)

--- a/lib/listings/base_field_descriptor.rb
+++ b/lib/listings/base_field_descriptor.rb
@@ -1,0 +1,17 @@
+module Listings
+  class BaseFieldDescriptor
+    attr_reader :path
+
+    def initialize(path)
+      @path = path
+    end
+
+    def build_field(listing)
+      listing.data_source.build_field(path)
+    end
+
+    def is_field?
+      !path.nil? && !path.is_a?(String)
+    end
+  end
+end

--- a/lib/listings/base_field_descriptor.rb
+++ b/lib/listings/base_field_descriptor.rb
@@ -2,10 +2,12 @@ module Listings
   class BaseFieldDescriptor
     attr_reader :path
     attr_reader :props
+    attr_reader :proc
 
-    def initialize(path, props)
+    def initialize(path, props, proc)
       @path = path
       @props = props
+      @proc = proc
     end
 
     def build_field(listing)

--- a/lib/listings/base_field_descriptor.rb
+++ b/lib/listings/base_field_descriptor.rb
@@ -1,9 +1,11 @@
 module Listings
   class BaseFieldDescriptor
     attr_reader :path
+    attr_reader :props
 
-    def initialize(path)
+    def initialize(path, props)
       @path = path
+      @props = props
     end
 
     def build_field(listing)

--- a/lib/listings/base_field_view.rb
+++ b/lib/listings/base_field_view.rb
@@ -18,6 +18,7 @@ module Listings
     end
 
     def human_name
+      return @field_description.props[:title] if @field_description.props[:title]
       return path if path.is_a?(String)
 
       I18n.t("listings.headers.#{listing.name}.#{key}", default: listing.human_name(field))

--- a/lib/listings/base_field_view.rb
+++ b/lib/listings/base_field_view.rb
@@ -20,15 +20,7 @@ module Listings
     def human_name
       return path if path.is_a?(String)
 
-      fallback = if is_model_column?
-        listing.model_class.human_attribute_name(path)
-      else
-        p = ::Listings::Sources::DataSource.sanitaize_path(path)
-        p = [p] unless p.is_a?(Array)
-        p.join(' ')
-      end
-
-      I18n.t("listings.headers.#{listing.name}.#{key}", default: fallback)
+      I18n.t("listings.headers.#{listing.name}.#{key}", default: listing.human_name(field))
     end
 
     def key
@@ -39,8 +31,8 @@ module Listings
       end
     end
 
-    def is_model_column?
-      path.is_a?(Symbol) && listing.has_active_model_source?
+    def is_field?
+      @field_description.is_field?
     end
   end
 end

--- a/lib/listings/base_field_view.rb
+++ b/lib/listings/base_field_view.rb
@@ -1,0 +1,46 @@
+module Listings
+  class BaseFieldView
+    attr_reader :field
+    attr_reader :listing
+
+    def initialize(listing, field_description)
+      @listing = listing
+      @field_description = field_description
+      @field = if @field_description.is_field?
+        @field_description.build_field(listing)
+      else
+        nil
+      end
+    end
+
+    def path
+      @field_description.path
+    end
+
+    def human_name
+      return path if path.is_a?(String)
+
+      fallback = if is_model_column?
+        listing.model_class.human_attribute_name(path)
+      else
+        p = ::Listings::Sources::DataSource.sanitaize_path(path)
+        p = [p] unless p.is_a?(Array)
+        p.join(' ')
+      end
+
+      I18n.t("listings.headers.#{listing.name}.#{key}", default: fallback)
+    end
+
+    def key
+      if @field
+        @field.key
+      else
+        path
+      end
+    end
+
+    def is_model_column?
+      path.is_a?(Symbol) && listing.has_active_model_source?
+    end
+  end
+end

--- a/lib/listings/column_descriptor.rb
+++ b/lib/listings/column_descriptor.rb
@@ -2,22 +2,13 @@ module Listings
   class ColumnDescriptor
     attr_reader :name
     attr_reader :props
+    attr_reader :proc
 
     def initialize(listing_class, name, props = {}, proc)
       @listing_class = listing_class
       @name = name
       @props = props.reverse_merge! searchable: false, sortable: true
       @proc = proc
-    end
-
-    def value_for(listing, model)
-      if @proc
-        listing.instance_exec model, &@proc
-      elsif model.is_a?(Hash)
-        model[name]
-      else
-        model.send(name)
-      end
     end
 
     def human_name(listing)

--- a/lib/listings/column_descriptor.rb
+++ b/lib/listings/column_descriptor.rb
@@ -1,11 +1,10 @@
 module Listings
   class ColumnDescriptor < BaseFieldDescriptor
-    attr_reader :props
     attr_reader :proc
 
-    def initialize(path, props = {}, proc)
-      super(path)
-      @props = props.reverse_merge! searchable: false, sortable: true
+    def initialize(path, props, proc)
+      props = props.reverse_merge! searchable: false, sortable: true
+      super(path, props)
       @proc = proc
     end
 

--- a/lib/listings/column_descriptor.rb
+++ b/lib/listings/column_descriptor.rb
@@ -1,29 +1,16 @@
 module Listings
-  class ColumnDescriptor
-    attr_reader :name
+  class ColumnDescriptor < BaseFieldDescriptor
     attr_reader :props
     attr_reader :proc
 
-    def initialize(listing_class, name, props = {}, proc)
-      @listing_class = listing_class
-      @name = name
+    def initialize(path, props = {}, proc)
+      super(path)
       @props = props.reverse_merge! searchable: false, sortable: true
       @proc = proc
     end
 
-    def human_name(listing)
-      return '' if name.blank?
-
-      fallback = if is_model_column?(listing)
-        listing.model_class.human_attribute_name(name)
-      else
-        name
-      end
-      I18n.t("listings.headers.#{listing.name}.#{name}", default: fallback)
-    end
-
-    def searchable?(listing)
-      @props[:searchable] && is_model_column?(listing)
+    def searchable?
+      @props[:searchable]
     end
 
     def sortable?
@@ -38,10 +25,6 @@ module Listings
     def sortable_property_is_expression?
       s = @props[:sortable]
       !(!!s == s)
-    end
-
-    def is_model_column?(listing)
-      name.is_a?(Symbol) && listing.has_active_model_source?
     end
   end
 end

--- a/lib/listings/column_descriptor.rb
+++ b/lib/listings/column_descriptor.rb
@@ -13,17 +13,7 @@ module Listings
     end
 
     def sortable?
-      s = @props[:sortable]
-      if sortable_property_is_expression?
-        true # s is the expression that should be used for sorting
-      else
-        s # s is Boolean
-      end
-    end
-
-    def sortable_property_is_expression?
-      s = @props[:sortable]
-      !(!!s == s)
+      @props[:sortable] && is_field?
     end
   end
 end

--- a/lib/listings/column_descriptor.rb
+++ b/lib/listings/column_descriptor.rb
@@ -1,11 +1,8 @@
 module Listings
   class ColumnDescriptor < BaseFieldDescriptor
-    attr_reader :proc
-
     def initialize(path, props, proc)
       props = props.reverse_merge! searchable: false, sortable: true
-      super(path, props)
-      @proc = proc
+      super(path, props, proc)
     end
 
     def searchable?

--- a/lib/listings/column_descriptor.rb
+++ b/lib/listings/column_descriptor.rb
@@ -9,7 +9,7 @@ module Listings
     end
 
     def searchable?
-      @props[:searchable]
+      @props[:searchable] && is_field?
     end
 
     def sortable?

--- a/lib/listings/column_view.rb
+++ b/lib/listings/column_view.rb
@@ -8,11 +8,10 @@ module Listings
       @field_description
     end
 
-    # TODO move to base_field_view
     def value_for(model)
-      if column_description.proc
+      if @field_description.proc
         # TODO should pass @field.value_for(model) to simplify formatting
-        listing.instance_exec model, &column_description.proc
+        listing.instance_exec model, &@field_description.proc
       else
         field.value_for(model)
       end

--- a/lib/listings/column_view.rb
+++ b/lib/listings/column_view.rb
@@ -23,15 +23,7 @@ module Listings
     end
 
     def sortable?
-      @listing.sortable? && column_description.sortable? && (is_field? || column_description.sortable_property_is_expression?)
-    end
-
-    def sort_by
-      if column_description.sortable_property_is_expression?
-        column_description.props[:sortable]
-      else
-        name
-      end
+      listing.sortable? && column_description.sortable?
     end
 
     def cell_css_class

--- a/lib/listings/column_view.rb
+++ b/lib/listings/column_view.rb
@@ -19,11 +19,11 @@ module Listings
     end
 
     def searchable?
-      column_description.searchable? && is_model_column?
+      column_description.searchable? && is_field?
     end
 
     def sortable?
-      @listing.is_sortable? && column_description.sortable? && (self.is_model_column? || column_description.sortable_property_is_expression?)
+      @listing.is_sortable? && column_description.sortable? && (is_field? || column_description.sortable_property_is_expression?)
     end
 
     def sort_by

--- a/lib/listings/column_view.rb
+++ b/lib/listings/column_view.rb
@@ -19,7 +19,7 @@ module Listings
     end
 
     def searchable?
-      column_description.searchable? && is_field?
+      column_description.searchable?
     end
 
     def sortable?
@@ -33,7 +33,7 @@ module Listings
     attr_accessor :sort
 
     def next_sort_direction
-      sort == 'asc' ? 'desc' : 'asc'
+      self.sort == Sources::DataSource::ASC ? Sources::DataSource::DESC : Sources::DataSource::ASC
     end
   end
 end

--- a/lib/listings/column_view.rb
+++ b/lib/listings/column_view.rb
@@ -10,8 +10,11 @@ module Listings
 
     def value_for(model)
       if @field_description.proc
-        # TODO should pass @field.value_for(model) to simplify formatting
-        listing.instance_exec model, &@field_description.proc
+        if is_field?
+          listing.instance_exec model, field.value_for(model), &@field_description.proc
+        else
+          listing.instance_exec model, &@field_description.proc
+        end
       else
         field.value_for(model)
       end

--- a/lib/listings/column_view.rb
+++ b/lib/listings/column_view.rb
@@ -1,12 +1,20 @@
 module Listings
   class ColumnView
+    attr_reader :field
+
     def initialize(listing, column_description)
       @listing = listing
       @column_description = column_description
+      @field = listing.data_source.build_field(column_description.name)
     end
 
     def value_for(model)
-      @column_description.value_for(@listing, model)
+      if @column_description.proc
+        # TODO should pass @field.value_for(model) to simplify formatting
+        @listing.instance_exec model, &@column_description.proc
+      else
+        @field.value_for(model)
+      end
     end
 
     def human_name

--- a/lib/listings/column_view.rb
+++ b/lib/listings/column_view.rb
@@ -23,7 +23,7 @@ module Listings
     end
 
     def sortable?
-      @listing.is_sortable? && column_description.sortable? && (is_field? || column_description.sortable_property_is_expression?)
+      @listing.sortable? && column_description.sortable? && (is_field? || column_description.sortable_property_is_expression?)
     end
 
     def sort_by

--- a/lib/listings/column_view.rb
+++ b/lib/listings/column_view.rb
@@ -1,52 +1,41 @@
 module Listings
-  class ColumnView
-    attr_reader :field
-
+  class ColumnView < BaseFieldView
     def initialize(listing, column_description)
-      @listing = listing
-      @column_description = column_description
-      @field = listing.data_source.build_field(column_description.name)
+      super
     end
 
+    def column_description
+      @field_description
+    end
+
+    # TODO move to base_field_view
     def value_for(model)
-      if @column_description.proc
+      if column_description.proc
         # TODO should pass @field.value_for(model) to simplify formatting
-        @listing.instance_exec model, &@column_description.proc
+        listing.instance_exec model, &column_description.proc
       else
-        @field.value_for(model)
+        field.value_for(model)
       end
     end
 
-    def human_name
-      @column_description.human_name(@listing)
-    end
-
     def searchable?
-      @column_description.searchable?(@listing)
-    end
-
-    def is_model_column?
-      @column_description.is_model_column?(@listing)
-    end
-
-    def name
-      @column_description.name
+      column_description.searchable? && is_model_column?
     end
 
     def sortable?
-      @listing.is_sortable? && @column_description.sortable? && (self.is_model_column? || @column_description.sortable_property_is_expression?)
+      @listing.is_sortable? && column_description.sortable? && (self.is_model_column? || column_description.sortable_property_is_expression?)
     end
 
     def sort_by
-      if @column_description.sortable_property_is_expression?
-        @column_description.props[:sortable]
+      if column_description.sortable_property_is_expression?
+        column_description.props[:sortable]
       else
         name
       end
     end
 
     def cell_css_class
-      @column_description.props[:class]
+      column_description.props[:class]
     end
 
     attr_accessor :sort

--- a/lib/listings/configuration_methods.rb
+++ b/lib/listings/configuration_methods.rb
@@ -1,6 +1,8 @@
 require 'listings/scope_descriptor'
 require 'listings/column_descriptor'
 require 'listings/column_view'
+require 'listings/filter_descriptor'
+require 'listings/filter_view'
 
 module Listings
   module ConfigurationMethods
@@ -11,7 +13,6 @@ module Listings
       attr_accessor :scope
       attr_accessor :search
       attr_accessor :page_size
-      attr_accessor :filter_values
 
       def scopes
         @scopes ||= self.class.process_scopes
@@ -49,7 +50,9 @@ module Listings
       end
 
       def filters
-        self.class.filters
+        @filters ||= self.class.filters.map do |fd|
+          FilterView.new(self, fd)
+        end
       end
     end
 
@@ -81,7 +84,6 @@ module Listings
         end
         @scopes = scopes.select{ |s| !s.deferred? }
       end
-
 
       def model(model_class = nil, &proc)
         if !model_class.nil?
@@ -136,8 +138,8 @@ module Listings
         @filters ||= []
       end
 
-      def filter name
-        filters << name
+      def filter(path)
+        filters << FilterDescriptor.new(self, path)
       end
     end
   end

--- a/lib/listings/configuration_methods.rb
+++ b/lib/listings/configuration_methods.rb
@@ -30,12 +30,12 @@ module Listings
         self.class.export_formats
       end
 
-      def is_sortable?
+      def sortable?
         opt = self.class.sortable_options
         if opt.nil?
           true
         else
-          if opt.length == 1 && !!opt.first == opt.first
+          if opt.length == 1
             opt.first
           else
             true
@@ -124,6 +124,8 @@ module Listings
         end
       end
 
+      # call `sortable false` make listing non sorted
+      # default is `sortable true`
       def sortable(*options)
         @sortable_options = options
       end

--- a/lib/listings/configuration_methods.rb
+++ b/lib/listings/configuration_methods.rb
@@ -155,7 +155,7 @@ module Listings
 
       def filter(path = '', props = {}, &proc)
         path, props = fix_path_props(path, props)
-        filters << FilterDescriptor.new(path, props)
+        filters << FilterDescriptor.new(path, props, proc)
       end
     end
   end

--- a/lib/listings/configuration_methods.rb
+++ b/lib/listings/configuration_methods.rb
@@ -101,8 +101,19 @@ module Listings
         @columns ||= []
       end
 
-      def column(name = '', props = {}, &proc)
-        columns << ColumnDescriptor.new(name, props, proc)
+      def column(path = '', props = {}, &proc)
+        path, props = fix_path_props(path, props)
+        columns << ColumnDescriptor.new(path, props, proc)
+      end
+
+      def fix_path_props(path, props)
+        if path.is_a?(Hash) && path.size > 1
+          props = props.merge(path)
+          path = Hash[[path.first]]
+          props.except!(path.first.first)
+        end
+
+        [path, props]
       end
 
       def selectable #(column = :id)
@@ -142,8 +153,9 @@ module Listings
         @filters ||= []
       end
 
-      def filter(path)
-        filters << FilterDescriptor.new(path)
+      def filter(path = '', props = {}, &proc)
+        path, props = fix_path_props(path, props)
+        filters << FilterDescriptor.new(path, props)
       end
     end
   end

--- a/lib/listings/configuration_methods.rb
+++ b/lib/listings/configuration_methods.rb
@@ -9,7 +9,6 @@ module Listings
     included do
       attr_accessor :page
       attr_accessor :scope
-      attr_accessor :items
       attr_accessor :search
       attr_accessor :page_size
       attr_accessor :filter_values

--- a/lib/listings/configuration_methods.rb
+++ b/lib/listings/configuration_methods.rb
@@ -1,4 +1,6 @@
 require 'listings/scope_descriptor'
+require 'listings/base_field_descriptor'
+require 'listings/base_field_view'
 require 'listings/column_descriptor'
 require 'listings/column_view'
 require 'listings/filter_descriptor'
@@ -100,7 +102,7 @@ module Listings
       end
 
       def column(name = '', props = {}, &proc)
-        columns << ColumnDescriptor.new(self, name, props, proc)
+        columns << ColumnDescriptor.new(name, props, proc)
       end
 
       def selectable #(column = :id)
@@ -139,7 +141,7 @@ module Listings
       end
 
       def filter(path)
-        filters << FilterDescriptor.new(self, path)
+        filters << FilterDescriptor.new(path)
       end
     end
   end

--- a/lib/listings/filter_descriptor.rb
+++ b/lib/listings/filter_descriptor.rb
@@ -1,10 +1,7 @@
 module Listings
-  class FilterDescriptor
-    attr_reader :path
-
-    def initialize(listing_class, path)
-      @listing_class = listing_class
-      @path = path
+  class FilterDescriptor < BaseFieldDescriptor
+    def initialize(path)
+      super
     end
   end
 end

--- a/lib/listings/filter_descriptor.rb
+++ b/lib/listings/filter_descriptor.rb
@@ -1,6 +1,6 @@
 module Listings
   class FilterDescriptor < BaseFieldDescriptor
-    def initialize(path)
+    def initialize(path, props)
       super
     end
   end

--- a/lib/listings/filter_descriptor.rb
+++ b/lib/listings/filter_descriptor.rb
@@ -1,0 +1,10 @@
+module Listings
+  class FilterDescriptor
+    attr_reader :path
+
+    def initialize(listing_class, path)
+      @listing_class = listing_class
+      @path = path
+    end
+  end
+end

--- a/lib/listings/filter_descriptor.rb
+++ b/lib/listings/filter_descriptor.rb
@@ -1,6 +1,6 @@
 module Listings
   class FilterDescriptor < BaseFieldDescriptor
-    def initialize(path, props)
+    def initialize(path, props, proc)
       super
     end
   end

--- a/lib/listings/filter_view.rb
+++ b/lib/listings/filter_view.rb
@@ -1,0 +1,23 @@
+module Listings
+  class FilterView
+    attr_reader :field
+
+    def initialize(listing, filter_description)
+      @listing = listing
+      @filter_description = filter_description
+      @field = listing.data_source.build_field(filter_description.path)
+    end
+
+    def human_name
+      key
+    end
+
+    def key
+      @field.key
+    end
+
+    def values
+      @values ||= @listing.data_source.values_for_filter(field)
+    end
+  end
+end

--- a/lib/listings/filter_view.rb
+++ b/lib/listings/filter_view.rb
@@ -1,23 +1,11 @@
 module Listings
-  class FilterView
-    attr_reader :field
-
+  class FilterView < BaseFieldView
     def initialize(listing, filter_description)
-      @listing = listing
-      @filter_description = filter_description
-      @field = listing.data_source.build_field(filter_description.path)
-    end
-
-    def human_name
-      key
-    end
-
-    def key
-      @field.key
+      super
     end
 
     def values
-      @values ||= @listing.data_source.values_for_filter(field)
+      @values ||= listing.data_source.values_for_filter(field)
     end
   end
 end

--- a/lib/listings/filter_view.rb
+++ b/lib/listings/filter_view.rb
@@ -7,5 +7,13 @@ module Listings
     def values
       @values ||= listing.data_source.values_for_filter(field)
     end
+
+    def value_for(value)
+      if @field_description.proc
+        listing.instance_exec value, &@field_description.proc
+      else
+        value
+      end
+    end
   end
 end

--- a/lib/listings/sources.rb
+++ b/lib/listings/sources.rb
@@ -2,5 +2,6 @@ module Listings::Sources
 end
 
 require 'listings/sources/data_source'
+require 'listings/sources/object_data_source'
 require 'listings/sources/active_record_data_source'
 

--- a/lib/listings/sources.rb
+++ b/lib/listings/sources.rb
@@ -1,0 +1,6 @@
+module Listings::Sources
+end
+
+require 'listings/sources/data_source'
+require 'listings/sources/active_record_data_source'
+

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -4,12 +4,13 @@ module Listings::Sources
 
     def initialize(model)
       @items = model
-      @items_for_filter = @items.clone
-      @model_instance = (if model.is_a?(ActiveRecord::Relation)
-        model.klass
+      if model.is_a?(ActiveRecord::Relation)
+        @items_for_filter = model.clone
+        @model_instance = model.klass.new
       else
-        model
-      end).new
+        @items_for_filter = model
+        @model_instance = model.new
+      end
     end
 
     def connection

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -12,6 +12,17 @@ module Listings::Sources
       @items = @items.page(page).per(page_size)
     end
 
+    def joins(relation)
+      @items = @items.eager_load(relation)
+    end
+
+    def build_field(path)
+      if path.is_a? Array
+        ActiveRecordAssociationField.new(path, self)
+      else
+        ActiveRecordField.new(path, self)
+      end
+    end
   end
 
   class DataSource
@@ -21,6 +32,35 @@ module Listings::Sources
       end
 
       alias_method_chain :for, :active_record
+    end
+  end
+
+  class ActiveRecordField < Field
+    def initialize(attribute_name, data_source)
+      super(data_source)
+      @attribute_name = attribute_name
+    end
+
+    def value_for(item)
+      item.send @attribute_name
+    end
+  end
+
+  class ActiveRecordAssociationField < Field
+    def initialize(path, data_source)
+      super(data_source)
+      @path = path
+
+      data_source.joins(path[0])
+    end
+
+    def value_for(item)
+      result = item
+      @path.each do |attribute_name|
+        result = result.send attribute_name
+      end
+
+      result
     end
   end
 end

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -19,7 +19,11 @@ module Listings::Sources
 
     def items
       if @items.is_a?(Class)
-        @items.scoped
+        if Rails::VERSION::MAJOR == 3
+          @items.scoped
+        else
+          @items.all
+        end
       else
         @items
       end

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -66,7 +66,7 @@ module Listings::Sources
     end
 
     def build_field(path)
-      path = self.sanitaize_path(path)
+      path = self.class.sanitaize_path(path)
       if path.is_a?(Array)
         ActiveRecordAssociationField.new(path, self)
       else

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -74,7 +74,11 @@ module Listings::Sources
   class DataSource
     class << self
       def for_with_active_record(model)
-        ActiveRecordDataSource.new(model)
+        if (model.is_a?(Class) && model.ancestors.include?(ActiveRecord::Base)) || model.is_a?(ActiveRecord::Relation)
+          ActiveRecordDataSource.new(model)
+        else
+          for_without_active_record(model)
+        end
       end
 
       alias_method_chain :for, :active_record

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -17,8 +17,10 @@ module Listings::Sources
     end
 
     def build_field(path)
-      if path.is_a? Array
+      if path.is_a?(Array)
         ActiveRecordAssociationField.new(path, self)
+      elsif path.is_a?(Hash) && path.size == 1
+        ActiveRecordAssociationField.new(path.to_a.first, self)
       else
         ActiveRecordField.new(path, self)
       end

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -1,12 +1,17 @@
 module Listings::Sources
   class ActiveRecordDataSource < DataSource
     def initialize(model)
-      @model = model
+      @items = model
     end
 
     def items
-      @model
+      @items
     end
+
+    def paginate(page, page_size)
+      @items = @items.page(page).per(page_size)
+    end
+
   end
 
   class DataSource

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -109,6 +109,10 @@ module Listings::Sources
     def sort(items, direction)
       items.reorder("#{query_column} #{direction}")
     end
+
+    def key
+      @attribute_name.to_s
+    end
   end
 
   class ActiveRecordAssociationField < Field
@@ -138,6 +142,10 @@ module Listings::Sources
 
     def sort(items, direction)
       items.reorder("#{query_column} #{direction}")
+    end
+
+    def key
+      @path.join('_')
     end
   end
 end

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -13,11 +13,19 @@ module Listings::Sources
     end
 
     def items
-      @items
+      if @items.is_a?(Class)
+        @items.scoped
+      else
+        @items
+      end
     end
 
     def scope
       @items = yield @items
+    end
+
+    def sort_with_direction(field, direction)
+      @items = field.sort @items, direction
     end
 
     def search(fields, value)
@@ -75,6 +83,10 @@ module Listings::Sources
     def query_column
       "#{quote_table_name(data_source.items.table_name)}.#{quote_column_name(@attribute_name)}"
     end
+
+    def sort(items, direction)
+      items.reorder("#{query_column} #{direction}")
+    end
   end
 
   class ActiveRecordAssociationField < Field
@@ -100,6 +112,10 @@ module Listings::Sources
     def query_column
       association = data_source.model_instance.association(@path[0])
       "#{quote_table_name(association.reflection.table_name)}.#{quote_column_name(@path[1])}"
+    end
+
+    def sort(items, direction)
+      items.reorder("#{query_column} #{direction}")
     end
   end
 end

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -44,6 +44,10 @@ module Listings::Sources
       @items = @items.where(criteria.join(' or '), *values)
     end
 
+    def filter(field, value)
+      @items = @items.where("#{field.query_column} = ?", value)
+    end
+
     def paginate(page, page_size)
       @items = @items.page(page).per(page_size)
     end

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -1,0 +1,21 @@
+module Listings::Sources
+  class ActiveRecordDataSource < DataSource
+    def initialize(model)
+      @model = model
+    end
+
+    def items
+      @model
+    end
+  end
+
+  class DataSource
+    class << self
+      def for_with_active_record(model)
+        ActiveRecordDataSource.new(model)
+      end
+
+      alias_method_chain :for, :active_record
+    end
+  end
+end

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -120,8 +120,7 @@ module Listings::Sources
     def value_for(item)
       result = item
       @path.each do |attribute_name|
-        # TODO deal with nils
-        result = result.send attribute_name
+        result = result.try { |o| o.send(attribute_name) }
       end
 
       result

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -1,7 +1,6 @@
 module Listings::Sources
   class ActiveRecordDataSource < DataSource
     attr_reader :model_instance
-    delegate :connection, to: :model_instance
 
     def initialize(model)
       @items = model
@@ -11,6 +10,10 @@ module Listings::Sources
       else
         model
       end).new
+    end
+
+    def connection
+      model_instance.class.connection
     end
 
     def items

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -8,6 +8,10 @@ module Listings::Sources
       @items
     end
 
+    def scope
+      @items = yield @items
+    end
+
     def paginate(page, page_size)
       @items = @items.page(page).per(page_size)
     end

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -113,6 +113,10 @@ module Listings::Sources
     def key
       @attribute_name.to_s
     end
+
+    def human_name
+      data_source.model_instance.class.human_attribute_name(@attribute_name)
+    end
   end
 
   class ActiveRecordAssociationField < Field
@@ -146,6 +150,10 @@ module Listings::Sources
 
     def key
       @path.join('_')
+    end
+
+    def human_name
+      @path.join(' ').titleize
     end
   end
 end

--- a/lib/listings/sources/active_record_data_source.rb
+++ b/lib/listings/sources/active_record_data_source.rb
@@ -61,10 +61,9 @@ module Listings::Sources
     end
 
     def build_field(path)
+      path = self.sanitaize_path(path)
       if path.is_a?(Array)
         ActiveRecordAssociationField.new(path, self)
-      elsif path.is_a?(Hash) && path.size == 1
-        ActiveRecordAssociationField.new(path.to_a.first, self)
       else
         ActiveRecordField.new(path, self)
       end
@@ -121,6 +120,7 @@ module Listings::Sources
     def value_for(item)
       result = item
       @path.each do |attribute_name|
+        # TODO deal with nils
         result = result.send attribute_name
       end
 

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -18,6 +18,10 @@ module Listings::Sources
     def search(fields, value)
     end
 
+    # applies exact match filtering among specified field
+    def filter(field, value)
+    end
+
     # applies sorting with specified direction to items
     # subclasses should implement +sort_with_direction+ in order to leave
     # default direction logic in +DataSource+
@@ -26,7 +30,7 @@ module Listings::Sources
     end
 
     # returns all values of field
-    # usually calling +search+/+sort+/+paginate+ should not affect the results.
+    # usually calling +search+/+filter+/+sort+/+paginate+ should not affect the results.
     # calling +scope+ should affect the results.
     def values_for_filter(field)
     end

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -69,5 +69,8 @@ module Listings::Sources
     # returns this field over the item
     def value_for(item)
     end
+
+    def key
+    end
   end
 end

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -12,6 +12,10 @@ module Listings::Sources
     def scope
     end
 
+    # applies a human friendly search to items among multiple fields
+    def search(fields, value)
+    end
+
     # apply pagination filter to +items+
     # items of the selected page can be obtained through +items+
     def paginate(page, page_size)

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -1,0 +1,7 @@
+module Listings::Sources
+  class DataSource
+    def self.for(model)
+      raise "Unable to create datasource for #{model}"
+    end
+  end
+end

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -47,6 +47,16 @@ module Listings::Sources
     def self.for(model)
       raise "Unable to create datasource for #{model}"
     end
+
+    def sanitaize_path(path)
+      if path.is_a?(Array)
+        path
+      elsif path.is_a?(Hash) && path.size == 1
+        path.to_a.first
+      else
+        path
+      end
+    end
   end
 
   class Field

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -48,7 +48,7 @@ module Listings::Sources
       raise "Unable to create datasource for #{model}"
     end
 
-    def sanitaize_path(path)
+    def self.sanitaize_path(path)
       if path.is_a?(Array)
         path
       elsif path.is_a?(Hash) && path.size == 1

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -25,6 +25,12 @@ module Listings::Sources
       sort_with_direction(field, direction)
     end
 
+    # returns all values of field
+    # usually calling +search+/+sort+/+paginate+ should not affect the results.
+    # calling +scope+ should affect the results.
+    def values_for_filter(field)
+    end
+
     # apply pagination filter to +items+
     # items of the selected page can be obtained through +items+
     def paginate(page, page_size)
@@ -46,6 +52,7 @@ module Listings::Sources
       @data_source = data_source
     end
 
+    # returns this field over the item
     def value_for(item)
     end
   end

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -11,8 +11,23 @@ module Listings::Sources
     def paginate(page, page_size)
     end
 
+    # returns a +Field+ for the specified options
+    def build_field(path)
+    end
+
     def self.for(model)
       raise "Unable to create datasource for #{model}"
+    end
+  end
+
+  class Field
+    attr_reader :data_source
+
+    def initialize(data_source)
+      @data_source = data_source
+    end
+
+    def value_for(item)
     end
   end
 end

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -1,5 +1,16 @@
 module Listings::Sources
   class DataSource
+
+    # returns items for the data source
+    # if +paginate+ is called, items will return just the current page
+    def items
+    end
+
+    # apply pagination filter to +items+
+    # items of the selected page can be obtained through +items+
+    def paginate(page, page_size)
+    end
+
     def self.for(model)
       raise "Unable to create datasource for #{model}"
     end

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -1,5 +1,7 @@
 module Listings::Sources
   class DataSource
+    DESC = 'desc'
+    ASC = 'asc'
 
     # returns items for the data source
     # if +paginate+ is called, items will return just the current page
@@ -14,6 +16,13 @@ module Listings::Sources
 
     # applies a human friendly search to items among multiple fields
     def search(fields, value)
+    end
+
+    # applies sorting with specified direction to items
+    # subclasses should implement +sort_with_direction+ in order to leave
+    # default direction logic in +DataSource+
+    def sort(field, direction = ASC)
+      sort_with_direction(field, direction)
     end
 
     # apply pagination filter to +items+

--- a/lib/listings/sources/data_source.rb
+++ b/lib/listings/sources/data_source.rb
@@ -6,6 +6,12 @@ module Listings::Sources
     def items
     end
 
+    # applies filter to the items
+    # scope will be called with a block with the ongoing items
+    # the result of the block is used as the narrowed items
+    def scope
+    end
+
     # apply pagination filter to +items+
     # items of the selected page can be obtained through +items+
     def paginate(page, page_size)

--- a/lib/listings/sources/object_data_source.rb
+++ b/lib/listings/sources/object_data_source.rb
@@ -79,5 +79,9 @@ module Listings::Sources
         end
       end
     end
+
+    def key
+      @path.join('_')
+    end
   end
 end

--- a/lib/listings/sources/object_data_source.rb
+++ b/lib/listings/sources/object_data_source.rb
@@ -10,8 +10,7 @@ module Listings::Sources
     end
 
     def paginate(page, page_size)
-      @items = Kaminari.paginate_array(@items)
-      @items = @items.page(page).per(page_size)
+      @items = Kaminari.paginate_array(@items).page(page).per(page_size)
     end
 
     def scope

--- a/lib/listings/sources/object_data_source.rb
+++ b/lib/listings/sources/object_data_source.rb
@@ -2,6 +2,54 @@ module Listings::Sources
   class ObjectDataSource < DataSource
     def initialize(items)
       @items = items
+      @items_for_filter = items
+    end
+
+    def items
+      @items
+    end
+
+    def paginate(page, page_size)
+      @items = Kaminari.paginate_array(@items)
+      @items = @items.page(page).per(page_size)
+    end
+
+    def scope
+      @items = yield @items
+      @items_for_filter = yield @items_for_filter
+    end
+
+    def sort_with_direction(field, direction)
+      @items = @items.sort do |a, b|
+        b, a = a, b if direction == DESC
+        field.value_for(a) <=> field.value_for(b)
+      end
+    end
+
+    def values_for_filter(field)
+      @items_for_filter.map { |o| field.value_for(o) }.uniq.reject(&:nil?).sort
+    end
+
+    def search(fields, value)
+      @items = @items.select do |item|
+        fields.any? do |field|
+          field.value_for(item).try { |o| o.include?(value) }
+        end
+      end
+    end
+
+    def filter(field, value)
+      @items = @items.select do |item|
+        field.value_for(item) == value
+      end
+    end
+
+    def build_field(path)
+      path = self.sanitaize_path(path)
+      unless path.is_a?(Array)
+        path = [path]
+      end
+      ObjectField.new(path, self)
     end
   end
 
@@ -12,6 +60,28 @@ module Listings::Sources
       end
 
       alias_method_chain :for, :object
+    end
+  end
+
+  class ObjectField < Field
+    def initialize(path, data_source)
+      super(data_source)
+      @path = path
+    end
+
+    def value_for(item)
+      @path.inject(item) do |obj, attribute|
+        # TODO deal with nils
+        if obj.is_a?(Hash) && obj.key?(attribute)
+          obj[attribute]
+        else
+          begin
+            obj.send attribute
+          rescue
+            binding.pry
+          end
+        end
+      end
     end
   end
 end

--- a/lib/listings/sources/object_data_source.rb
+++ b/lib/listings/sources/object_data_source.rb
@@ -44,7 +44,7 @@ module Listings::Sources
     end
 
     def build_field(path)
-      path = self.sanitaize_path(path)
+      path = self.class.sanitaize_path(path)
       unless path.is_a?(Array)
         path = [path]
       end

--- a/lib/listings/sources/object_data_source.rb
+++ b/lib/listings/sources/object_data_source.rb
@@ -71,15 +71,12 @@ module Listings::Sources
 
     def value_for(item)
       @path.inject(item) do |obj, attribute|
-        # TODO deal with nils
-        if obj.is_a?(Hash) && obj.key?(attribute)
+        if obj.nil?
+          nil
+        elsif obj.is_a?(Hash) && obj.key?(attribute)
           obj[attribute]
         else
-          begin
-            obj.send attribute
-          rescue
-            binding.pry
-          end
+          obj.send attribute
         end
       end
     end

--- a/lib/listings/sources/object_data_source.rb
+++ b/lib/listings/sources/object_data_source.rb
@@ -1,0 +1,17 @@
+module Listings::Sources
+  class ObjectDataSource < DataSource
+    def initialize(items)
+      @items = items
+    end
+  end
+
+  class DataSource
+    class << self
+      def for_with_object(model)
+        ObjectDataSource.new(model)
+      end
+
+      alias_method_chain :for, :object
+    end
+  end
+end

--- a/lib/listings/sources/object_data_source.rb
+++ b/lib/listings/sources/object_data_source.rb
@@ -83,5 +83,9 @@ module Listings::Sources
     def key
       @path.join('_')
     end
+
+    def human_name
+      @path.join(' ')
+    end
   end
 end

--- a/lib/rspec/listings_helpers.rb
+++ b/lib/rspec/listings_helpers.rb
@@ -1,15 +1,33 @@
 module RSpec::ListingsHelpers
-  class FakeViewContext
-    include ::Listings::ActionViewExtensions
+  class FakeRoutes
+    def listing_full_path(*options)
+      "/"
+    end
 
-    def listings
-      nil
+    def listing_full_url(*options)
+      "/"
     end
   end
 
   def query_listing(name)
-    context = FakeViewContext.new
+    context = fake_context
     context.prepare_listing({:listing => name}, context)
+  end
+
+  def render_listing(name)
+    fake_context.render_listing(name)
+  end
+
+  def fake_context
+    controller = ActionController::Base.new
+    controller.request = ActionController::TestRequest.new(:host => "http://test.com")
+    context = controller.view_context
+
+    context.class.send(:define_method, 'listings') do
+      FakeRoutes.new
+    end
+
+    context
   end
 
 end

--- a/lib/rspec/listings_helpers.rb
+++ b/lib/rspec/listings_helpers.rb
@@ -7,6 +7,10 @@ module RSpec::ListingsHelpers
     def listing_full_url(*options)
       "/"
     end
+
+    def listing_content_url(*options)
+      "/"
+    end
   end
 
   def query_listing(name)

--- a/spec/dummy/app/controllers/welcome_controller.rb
+++ b/spec/dummy/app/controllers/welcome_controller.rb
@@ -7,4 +7,7 @@ class WelcomeController < ApplicationController
 
   def hash
   end
+
+  def tracks
+  end
 end

--- a/spec/dummy/app/listings/array_listing.rb
+++ b/spec/dummy/app/listings/array_listing.rb
@@ -10,6 +10,7 @@ class ArrayListing < Listings::Base
     end
   end
 
+  # paginates_per :none
   paginates_per 10
 
   column 'Num' do |n|

--- a/spec/dummy/app/listings/tracks_fixed_order_listing.rb
+++ b/spec/dummy/app/listings/tracks_fixed_order_listing.rb
@@ -1,0 +1,13 @@
+class TracksFixedOrderListing < Listings::Base
+
+  model Track
+
+  sortable false
+
+  filter album: :name
+
+  column :order
+  column :title
+  column album: :name
+
+end

--- a/spec/dummy/app/listings/tracks_listing.rb
+++ b/spec/dummy/app/listings/tracks_listing.rb
@@ -3,7 +3,9 @@ class TracksListing < Listings::Base
   model Track
 
   filter album: :name
-  filter album: :id, title: 'The Album Id'
+  filter album: :id, title: 'The Album Id' do |value|
+    "#{value}!"
+  end
 
   column :order
   column :title, searchable: true

--- a/spec/dummy/app/listings/tracks_listing.rb
+++ b/spec/dummy/app/listings/tracks_listing.rb
@@ -1,0 +1,9 @@
+class TracksListing < Listings::Base
+
+  model Track
+
+  column :order
+  column :title
+  column [:album, :name] # handle has_many relations
+
+end

--- a/spec/dummy/app/listings/tracks_listing.rb
+++ b/spec/dummy/app/listings/tracks_listing.rb
@@ -4,6 +4,6 @@ class TracksListing < Listings::Base
 
   column :order
   column :title
-  column [:album, :name] # handle has_many relations
+  # column [:album, :name] # handle has_many relations
 
 end

--- a/spec/dummy/app/listings/tracks_listing.rb
+++ b/spec/dummy/app/listings/tracks_listing.rb
@@ -2,6 +2,8 @@ class TracksListing < Listings::Base
 
   model Track
 
+  filter album: :name
+
   column :order
   column :title
   column album: :name

--- a/spec/dummy/app/listings/tracks_listing.rb
+++ b/spec/dummy/app/listings/tracks_listing.rb
@@ -4,6 +4,6 @@ class TracksListing < Listings::Base
 
   column :order
   column :title
-  # column [:album, :name] # handle has_many relations
+  column album: :name
 
 end

--- a/spec/dummy/app/listings/tracks_listing.rb
+++ b/spec/dummy/app/listings/tracks_listing.rb
@@ -9,7 +9,10 @@ class TracksListing < Listings::Base
 
   column :order
   column :title, searchable: true
-  column album: :name, searchable: true
+  column album: :name, searchable: true do |track, album_name|
+    "#{album_name} (Buy!)"
+  end
+
   column album: :id, title: 'The Album Id'
 
 end

--- a/spec/dummy/app/listings/tracks_listing.rb
+++ b/spec/dummy/app/listings/tracks_listing.rb
@@ -3,9 +3,11 @@ class TracksListing < Listings::Base
   model Track
 
   filter album: :name
+  filter album: :id, title: 'The Album Id'
 
   column :order
-  column :title
-  column album: :name
+  column :title, searchable: true
+  column album: :name, searchable: true
+  column album: :id, title: 'The Album Id'
 
 end

--- a/spec/dummy/app/models/album.rb
+++ b/spec/dummy/app/models/album.rb
@@ -1,0 +1,4 @@
+class Album < ActiveRecord::Base
+  attr_accessible :name if Rails::VERSION::MAJOR == 3
+  has_many :tracks
+end

--- a/spec/dummy/app/models/object_album.rb
+++ b/spec/dummy/app/models/object_album.rb
@@ -1,4 +1,8 @@
 class ObjectAlbum
   attr_accessor :name
   attr_accessor :tracks
+
+  def to_h
+    { name: name }
+  end
 end

--- a/spec/dummy/app/models/object_album.rb
+++ b/spec/dummy/app/models/object_album.rb
@@ -1,0 +1,4 @@
+class ObjectAlbum
+  attr_accessor :name
+  attr_accessor :tracks
+end

--- a/spec/dummy/app/models/object_track.rb
+++ b/spec/dummy/app/models/object_track.rb
@@ -1,0 +1,4 @@
+class ObjectTrack
+  attr_accessor :album
+  attr_accessor :order, :title
+end

--- a/spec/dummy/app/models/object_track.rb
+++ b/spec/dummy/app/models/object_track.rb
@@ -1,4 +1,8 @@
 class ObjectTrack
   attr_accessor :album
   attr_accessor :order, :title
+
+  def to_h
+    { title: title, album: album.try(&:to_h) }
+  end
 end

--- a/spec/dummy/app/models/track.rb
+++ b/spec/dummy/app/models/track.rb
@@ -1,0 +1,4 @@
+class Track < ActiveRecord::Base
+  belongs_to :album
+  attr_accessible :order, :title if Rails::VERSION::MAJOR == 3
+end

--- a/spec/dummy/app/models/track.rb
+++ b/spec/dummy/app/models/track.rb
@@ -1,4 +1,7 @@
 class Track < ActiveRecord::Base
   belongs_to :album
   attr_accessible :order, :title if Rails::VERSION::MAJOR == 3
+
+  scope :even, -> { where("#{table_name}.id % 2 = 0") }
+
 end

--- a/spec/dummy/app/views/welcome/index.html.haml
+++ b/spec/dummy/app/views/welcome/index.html.haml
@@ -2,6 +2,12 @@
 
 %dl
   %dt
+    = link_to 'Tracks', tracks_path
+  %dd
+    ActiveRecord based listing with association handling
+
+%dl
+  %dt
     = link_to 'Posts', posts_path
   %dd
     ActiveRecord based listing with scopes, deferred_scopes, styles and selectable

--- a/spec/dummy/app/views/welcome/index.html.haml
+++ b/spec/dummy/app/views/welcome/index.html.haml
@@ -26,6 +26,6 @@
 
 %dl
   %dt
-    = link_to 'Array', hash_path
+    = link_to 'Array', array_path
   %dd
     Array based listing

--- a/spec/dummy/app/views/welcome/tracks.html.haml
+++ b/spec/dummy/app/views/welcome/tracks.html.haml
@@ -1,0 +1,3 @@
+%h1 Welcome#tracks
+
+= render_listing :tracks

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
   get 'array', to: 'welcome#array'
   get 'hash', to: 'welcome#hash'
+  get 'tracks', to: 'welcome#tracks'
 
   root to: 'welcome#index'
 

--- a/spec/dummy/db/migrate/20150611185824_create_albums.rb
+++ b/spec/dummy/db/migrate/20150611185824_create_albums.rb
@@ -1,0 +1,9 @@
+class CreateAlbums < ActiveRecord::Migration
+  def change
+    create_table :albums do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20150611185922_create_tracks.rb
+++ b/spec/dummy/db/migrate/20150611185922_create_tracks.rb
@@ -1,0 +1,12 @@
+class CreateTracks < ActiveRecord::Migration
+  def change
+    create_table :tracks do |t|
+      t.string :title
+      t.integer :order
+      t.references :album
+
+      t.timestamps
+    end
+    add_index :tracks, :album_id
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,13 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140728151246) do
+ActiveRecord::Schema.define(:version => 20150611185922) do
+
+  create_table "albums", :force => true do |t|
+    t.string   "name"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
 
   create_table "posts", :force => true do |t|
     t.string   "title"
@@ -20,5 +26,15 @@ ActiveRecord::Schema.define(:version => 20140728151246) do
     t.text     "author"
     t.string   "category"
   end
+
+  create_table "tracks", :force => true do |t|
+    t.string   "title"
+    t.integer  "order"
+    t.integer  "album_id"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "tracks", ["album_id"], :name => "index_tracks_on_album_id"
 
 end

--- a/spec/dummy/db/seeds.rb
+++ b/spec/dummy/db/seeds.rb
@@ -1,5 +1,11 @@
+require 'factory_girl'
+# Dir[Rails.root.join("spec/factories/*.rb")].each {|f| require f}
 
 (1..100).each do |sn|
   Post.create! title: "post n-#{sn}", author: "john-#{(sn % 4) + 1}", category: "category-#{(sn % 3) + 1}"
 end
 
+
+(1..10).each do |sn|
+  FactoryGirl.create :album
+end

--- a/spec/factories/albums.rb
+++ b/spec/factories/albums.rb
@@ -19,7 +19,7 @@ FactoryGirl.define do
     end
 
     after(:build) do |album, evaluator|
-      build_list(:object_track, evaluator.tracks_count, album: album)
+      album.tracks = build_list(:object_track, evaluator.tracks_count, album: album)
     end
   end
 end

--- a/spec/factories/albums.rb
+++ b/spec/factories/albums.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :album do
-    name "MyString"
+    name
 
     transient do
       tracks_count 5

--- a/spec/factories/albums.rb
+++ b/spec/factories/albums.rb
@@ -11,4 +11,15 @@ FactoryGirl.define do
     end
   end
 
+  factory :object_album do
+    name
+
+    transient do
+      tracks_count 5
+    end
+
+    after(:build) do |album, evaluator|
+      build_list(:object_track, evaluator.tracks_count, album: album)
+    end
+  end
 end

--- a/spec/factories/albums.rb
+++ b/spec/factories/albums.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  factory :album do
+    name "MyString"
+
+    transient do
+      tracks_count 5
+    end
+
+    after(:create) do |album, evaluator|
+      create_list(:track, evaluator.tracks_count, album: album)
+    end
+  end
+
+end

--- a/spec/factories/post.rb
+++ b/spec/factories/post.rb
@@ -1,4 +1,5 @@
 FactoryGirl.define do
   factory :post do
+    title
   end
 end

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -5,4 +5,10 @@ FactoryGirl.define do
     album nil
   end
 
+  factory :object_track do
+    title
+    order 1
+    album nil
+  end
+
 end

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :track do
-    title "MyString"
+    title
     order 1
     album nil
   end

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :track do
+    title "MyString"
+    order 1
+    album nil
+  end
+
+end

--- a/spec/factories/traits.rb
+++ b/spec/factories/traits.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   sequence :title do |n|
-    "title #{n}"
+    "title #{rand(1000)} #{n}"
   end
 
   sequence :name do |n|
-    "name #{n}"
+    "name #{rand(1000)} #{n}"
   end
 end

--- a/spec/factories/traits.rb
+++ b/spec/factories/traits.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  sequence :title do |n|
+    "title #{n}"
+  end
+
+  sequence :name do |n|
+    "name #{n}"
+  end
+end

--- a/spec/lib/filter_parser_spec.rb
+++ b/spec/lib/filter_parser_spec.rb
@@ -21,6 +21,9 @@ describe Listings do
     assert_parse_filter "author:'John Doe:s'", {author: "John Doe:s"}, ""
 
     assert_parse_filter "bar author:'me:s' baz category:\"foo foo\"", {author: "me:s", category: "foo foo"}, "bar baz"
+
+    assert_parse_filter "album_name:me", {album_name: "me"}, ""
+    assert_parse_filter "album_name:'me 2' ", {album_name: "me 2"}, ""
   end
 
   def assert_parse_filter(text, hash, left_text)

--- a/spec/lib/filter_parser_spec.rb
+++ b/spec/lib/filter_parser_spec.rb
@@ -5,6 +5,8 @@ describe Listings do
     assert_parse_filter "author:me", {author: "me"}, ""
     assert_parse_filter "Author:me", {author: "me"}, ""
 
+    assert_parse_filter "101", {}, "101"
+
     assert_parse_filter "author:me category:foo", {author: "me", category: "foo"}, ""
     assert_parse_filter "   author:  me    category:  foo", {author: "me", category: "foo"}, ""
     assert_parse_filter "   author:  'me'    category:  foo", {author: "me", category: "foo"}, ""

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -112,6 +112,19 @@ RSpec.describe ActiveRecordDataSource do
         end
       end
 
+      describe "filter" do
+        before(:each) do
+          create_list(:post, 10, author: 'author1')
+          create_list(:post, 10, author: 'author2')
+
+          ds.filter(author, 'author1')
+        end
+
+        it "should return matching items" do
+          expect(ds.items.count).to be(10)
+        end
+      end
+
       describe "values_for_filter" do
         let(:total_count) { 0 } # skip default test posts
 
@@ -152,7 +165,15 @@ RSpec.describe ActiveRecordDataSource do
           it_behaves_like "project all authors"
         end
 
-        context "with search" do
+        context "with filter" do
+          before(:each) do
+            ds.filter(author, 'author2')
+          end
+
+          it_behaves_like "project all authors"
+        end
+
+        context "with paging" do
           before(:each) do
             ds.paginate(1, 1)
           end
@@ -229,6 +250,19 @@ RSpec.describe ActiveRecordDataSource do
         it "should return matching items" do
           show_query ds
           expect(ds.items.count).to be(20)
+        end
+      end
+
+      describe "filter" do
+        before(:each) do
+          create(:album, tracks_count: 5, name: 'album-name-magic-string-1')
+          create(:album, tracks_count: 5, name: 'album-name-magic-string-2')
+
+          ds.filter(album_name, 'album-name-magic-string-1')
+        end
+
+        it "should return matching items" do
+          expect(ds.items.count).to be(5)
         end
       end
 

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -2,7 +2,9 @@ include Listings::Sources
 
 RSpec.describe ActiveRecordDataSource do
 
-  before(:each) { create_list(:post, 40) }
+  TOTAL_COUNT = 40
+
+  before(:each) { create_list(:post, TOTAL_COUNT) }
 
   shared_examples "activerecord datasource with all item" do
     describe "DataSource factory" do
@@ -12,9 +14,22 @@ RSpec.describe ActiveRecordDataSource do
     end
 
     describe "items" do
-
       it "should return all items" do
-        expect(ds.items.count).to be(40)
+        expect(ds.items.count).to be(TOTAL_COUNT)
+      end
+    end
+
+    describe "paginate" do
+      PAGE_SIZE = 5
+
+      before(:each) { ds.paginate(2, PAGE_SIZE) }
+
+      it "should get only paged items" do
+        expect(ds.items.count).to be(PAGE_SIZE)
+      end
+
+      it "should keep total_count" do
+        expect(ds.items.total_count).to be(TOTAL_COUNT)
       end
     end
   end
@@ -25,8 +40,7 @@ RSpec.describe ActiveRecordDataSource do
   end
 
   context "using relation" do
-    let(:ds) { DataSource.for(Post.all) }
+    let(:ds) { DataSource.for(Post.where('1 = 1')) }
     it_behaves_like "activerecord datasource with all item"
   end
-
 end

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -2,45 +2,74 @@ include Listings::Sources
 
 RSpec.describe ActiveRecordDataSource do
 
-  TOTAL_COUNT = 40
+  context "simple active record model" do
+    TOTAL_COUNT = 40
 
-  before(:each) { create_list(:post, TOTAL_COUNT) }
+    let!(:posts) { create_list(:post, TOTAL_COUNT) }
+    let(:title) { ds.build_field :title }
 
-  shared_examples "activerecord datasource with all item" do
-    describe "DataSource factory" do
-      it "should create from with class name" do
-        expect(ds).to be_a ActiveRecordDataSource
+    shared_examples "activerecord datasource with all item" do
+      describe "DataSource factory" do
+        it "should create from with class name" do
+          expect(ds).to be_a ActiveRecordDataSource
+        end
+      end
+
+      describe "items" do
+        it "should return all items" do
+          expect(ds.items.count).to be(TOTAL_COUNT)
+        end
+      end
+
+      describe "paginate" do
+        PAGE_SIZE = 5
+
+        before(:each) { ds.paginate(2, PAGE_SIZE) }
+
+        it "should get only paged items" do
+          expect(ds.items.count).to be(PAGE_SIZE)
+        end
+
+        it "should keep total_count" do
+          expect(ds.items.total_count).to be(TOTAL_COUNT)
+        end
+      end
+
+      describe "field" do
+        it "should project attribute value" do
+          expect(title.value_for(ds.items.first)).to eq(posts.first.title)
+        end
       end
     end
 
-    describe "items" do
-      it "should return all items" do
-        expect(ds.items.count).to be(TOTAL_COUNT)
-      end
+    context "using class" do
+      let(:ds) { DataSource.for(Post) }
+      it_behaves_like "activerecord datasource with all item"
     end
 
-    describe "paginate" do
-      PAGE_SIZE = 5
-
-      before(:each) { ds.paginate(2, PAGE_SIZE) }
-
-      it "should get only paged items" do
-        expect(ds.items.count).to be(PAGE_SIZE)
-      end
-
-      it "should keep total_count" do
-        expect(ds.items.total_count).to be(TOTAL_COUNT)
-      end
+    context "using relation" do
+      let(:ds) { DataSource.for(Post.where('1 = 1')) }
+      it_behaves_like "activerecord datasource with all item"
     end
   end
 
-  context "using class" do
-    let(:ds) { DataSource.for(Post) }
-    it_behaves_like "activerecord datasource with all item"
-  end
+  context "active record model with belongs_to" do
+    let!(:albums) { create_list(:album, 5) }
+    let(:ds) { DataSource.for(Track) }
+    let!(:album_name) { ds.build_field [:album, :name] }
+    let!(:album_id) { ds.build_field [:album, :id] }
 
-  context "using relation" do
-    let(:ds) { DataSource.for(Post.where('1 = 1')) }
-    it_behaves_like "activerecord datasource with all item"
+    describe "field" do
+      it "should project attribute value" do
+        expect(album_name.value_for(ds.items.first)).to eq(Track.first.album.name)
+      end
+
+      it "should perform a single query" do
+        expect(ActiveRecord::Base.count_queries do
+          album_name.value_for(ds.items.first)
+          album_name.value_for(ds.items.first)
+        end).to eq(1)
+      end
+    end
   end
 end

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe ActiveRecordDataSource do
         it "should return all items" do
           expect(ds.items.count).to be(TOTAL_COUNT)
         end
+
+        it "should enumerate all items" do
+          expect(begin
+            c = 0
+            ds.items.each do
+              c = c + 1
+            end
+            c
+          end).to be(TOTAL_COUNT)
+        end
       end
 
       describe "paginate" do
@@ -77,6 +87,28 @@ RSpec.describe ActiveRecordDataSource do
 
         it "should return matching items" do
           expect(ds.items.count).to be(20)
+        end
+      end
+
+      describe "sort" do
+        before(:each) do
+          expect(posts.map(&:title)).to_not eq(posts.map(&:title).sort)
+          ds.sort(title)
+        end
+
+        it "should return matching items" do
+          expect(ds.items.map { |e| title.value_for(e) }).to eq(posts.map(&:title).sort)
+        end
+      end
+
+      describe "sort desc" do
+        before(:each) do
+          expect(posts.map(&:title)).to_not eq(posts.map(&:title).sort.reverse)
+          ds.sort(title, DataSource::DESC)
+        end
+
+        it "should return matching items" do
+          expect(ds.items.map { |e| title.value_for(e) }).to eq(posts.map(&:title).sort.reverse)
         end
       end
     end
@@ -139,6 +171,36 @@ RSpec.describe ActiveRecordDataSource do
         it "should return matching items" do
           show_query ds
           expect(ds.items.count).to be(20)
+        end
+      end
+
+      describe "sort" do
+        def all_track_albumns_name
+          Track.all.map { |t| t.album.name }
+        end
+
+        before(:each) do
+          expect(all_track_albumns_name).to_not eq(all_track_albumns_name.sort)
+          ds.sort(album_name)
+        end
+
+        it "should return matching items" do
+          expect(ds.items.map { |e| album_name.value_for(e) }).to eq(all_track_albumns_name.sort)
+        end
+      end
+
+      describe "sort desc" do
+        def all_track_albumns_name
+          Track.all.map { |t| t.album.name }
+        end
+
+        before(:each) do
+          expect(all_track_albumns_name).to_not eq(all_track_albumns_name.sort.reverse)
+          ds.sort(album_name, DataSource::DESC)
+        end
+
+        it "should return matching items" do
+          expect(ds.items.map { |e| album_name.value_for(e) }).to eq(all_track_albumns_name.sort.reverse)
         end
       end
     end

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe ActiveRecordDataSource do
         it "should project attribute value" do
           expect(title.value_for(ds.items.first)).to eq(posts.first.title)
         end
+
+        it "should have key" do
+          expect(title.key).to eq('title')
+        end
       end
 
       describe "scope" do
@@ -209,8 +213,14 @@ RSpec.describe ActiveRecordDataSource do
     let!(:track_title) { ds.build_field :title }
 
     shared_examples "listing with projected values" do
-      it "should project attribute value" do
-        expect(album_name.value_for(ds.items.first)).to eq(Track.first.album.name)
+      describe "projected field" do
+        it "should project attribute value" do
+          expect(album_name.value_for(ds.items.first)).to eq(Track.first.album.name)
+        end
+
+        it "should have key" do
+          expect(album_name.key).to eq('album_name')
+        end
       end
 
       it "should deal with intermediate nils" do

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -213,6 +213,11 @@ RSpec.describe ActiveRecordDataSource do
         expect(album_name.value_for(ds.items.first)).to eq(Track.first.album.name)
       end
 
+      it "should deal with intermediate nils" do
+        track_without_album = create(:track, album: nil)
+        expect(album_name.value_for(track_without_album)).to be_nil
+      end
+
       it "should perform a eager_load" do
         show_query ds
       end

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -1,0 +1,32 @@
+include Listings::Sources
+
+RSpec.describe ActiveRecordDataSource do
+
+  before(:each) { create_list(:post, 40) }
+
+  shared_examples "activerecord datasource with all item" do
+    describe "DataSource factory" do
+      it "should create from with class name" do
+        expect(ds).to be_a ActiveRecordDataSource
+      end
+    end
+
+    describe "items" do
+
+      it "should return all items" do
+        expect(ds.items.count).to be(40)
+      end
+    end
+  end
+
+  context "using class" do
+    let(:ds) { DataSource.for(Post) }
+    it_behaves_like "activerecord datasource with all item"
+  end
+
+  context "using relation" do
+    let(:ds) { DataSource.for(Post.all) }
+    it_behaves_like "activerecord datasource with all item"
+  end
+
+end

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe ActiveRecordDataSource do
           expect(title.value_for(ds.items.first)).to eq(posts.first.title)
         end
       end
+
+      describe "scope" do
+        before(:each) do
+          ds.scope do |items|
+            items.even
+          end
+        end
+
+        it "should return scoped items" do
+          expect(ds.items.count).to be(TOTAL_COUNT / 2)
+        end
+      end
     end
 
     context "using class" do
@@ -54,7 +66,7 @@ RSpec.describe ActiveRecordDataSource do
   end
 
   context "active record model with belongs_to" do
-    let!(:albums) { create_list(:album, 5) }
+    let!(:albums) { create_list(:album, 6) }
     let(:ds) { DataSource.for(Track) }
 
     shared_examples "listing with projected values" do
@@ -70,6 +82,18 @@ RSpec.describe ActiveRecordDataSource do
           album_id.value_for(ds.items.first)
         end).to eq(1)
         # ActiveRecord::Base.logger = nil
+      end
+
+      describe "scope" do
+        before(:each) do
+          ds.scope do |items|
+            items.even
+          end
+        end
+
+        it "should return scoped items" do
+          expect(ds.items.count).to be(Track.count / 2)
+        end
       end
     end
 

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -65,10 +65,13 @@ RSpec.describe ActiveRecordDataSource do
       end
 
       it "should perform a single query" do
+        # ActiveRecord::Base.logger = Logger.new(STDOUT)
+        # puts
         expect(ActiveRecord::Base.count_queries do
           album_name.value_for(ds.items.first)
-          album_name.value_for(ds.items.first)
+          album_id.value_for(ds.items.first)
         end).to eq(1)
+        # ActiveRecord::Base.logger = nil
       end
     end
   end

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -56,10 +56,8 @@ RSpec.describe ActiveRecordDataSource do
   context "active record model with belongs_to" do
     let!(:albums) { create_list(:album, 5) }
     let(:ds) { DataSource.for(Track) }
-    let!(:album_name) { ds.build_field [:album, :name] }
-    let!(:album_id) { ds.build_field [:album, :id] }
 
-    describe "field" do
+    shared_examples "listing with projected values" do
       it "should project attribute value" do
         expect(album_name.value_for(ds.items.first)).to eq(Track.first.album.name)
       end
@@ -73,6 +71,20 @@ RSpec.describe ActiveRecordDataSource do
         end).to eq(1)
         # ActiveRecord::Base.logger = nil
       end
+    end
+
+    context "using array as path" do
+      let!(:album_name) { ds.build_field [:album, :name] }
+      let!(:album_id) { ds.build_field [:album, :id] }
+
+      it_behaves_like "listing with projected values"
+    end
+
+    context "hash as path" do
+      let!(:album_name) { ds.build_field album: :name }
+      let!(:album_id) { ds.build_field album: :id }
+
+      it_behaves_like "listing with projected values"
     end
   end
 end

--- a/spec/lib/sources/active_record_data_source_spec.rb
+++ b/spec/lib/sources/active_record_data_source_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe ActiveRecordDataSource do
     let(:title) { ds.build_field :title }
     let(:author) { ds.build_field :author }
 
+    shared_examples "project all authors" do
+      it "should matching values" do
+        expect(ds.values_for_filter(author)).to eq(['author1', 'author2', 'author3'])
+      end
+    end
+
     shared_examples "activerecord datasource with all item" do
       describe "DataSource factory" do
         it "should create from with class name" do
@@ -46,12 +52,12 @@ RSpec.describe ActiveRecordDataSource do
       end
 
       describe "paginate" do
-        PAGE_SIZE = 5
+        let(:page_size) { 5 }
 
-        before(:each) { ds.paginate(2, PAGE_SIZE) }
+        before(:each) { ds.paginate(2, page_size) }
 
         it "should get only paged items" do
-          expect(ds.items.count).to be(PAGE_SIZE)
+          expect(ds.items.count).to be(page_size)
         end
 
         it "should keep total_count" do
@@ -133,12 +139,6 @@ RSpec.describe ActiveRecordDataSource do
           create_list(:post, 10, author: 'author1')
           create_list(:post, 10, author: 'author2')
           create_list(:post, 10, author: nil)
-        end
-
-        shared_examples "project all authors" do
-          it "should matching values" do
-            expect(ds.values_for_filter(author)).to eq(['author1', 'author2', 'author3'])
-          end
         end
 
         context "without search" do

--- a/spec/lib/sources/object_data_source_spec.rb
+++ b/spec/lib/sources/object_data_source_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe ObjectDataSource do
         expect(ds).to be_a(ObjectDataSource)
       end
 
+      describe "field" do
+        let(:tracks) { [] }
+        before(:each) {
+          add_tracks build(:object_track, album: nil)
+        }
+        it "should deal with intermediate nils" do
+          expect(album_name.value_for(ds.items.first)).to be_nil
+        end
+      end
+
       describe "items" do
         it "should list all" do
           expect(ds.items.count).to be(tracks.count)
@@ -200,7 +210,7 @@ RSpec.describe ObjectDataSource do
   end
 
   context "using array of hash" do
-    let(:ds) { DataSource.for(tracks.map{ |t| {title: t.title, album: {name: t.album.name } } }) }
+    let(:ds) { DataSource.for(tracks.map(&:to_h)) }
     let(:album_name) { nil }
 
     context "and hash like fields" do

--- a/spec/lib/sources/object_data_source_spec.rb
+++ b/spec/lib/sources/object_data_source_spec.rb
@@ -4,12 +4,181 @@ RSpec.describe ObjectDataSource do
 
   shared_examples "object datasource" do
     let(:tracks) {
-      build_list(:object_track, 5)
+      build_list(:object_album, 10).map(&:tracks).flatten
     }
 
+    def add_tracks(ts)
+      if ts.is_a?(Array)
+        ts.each { |t| add_tracks t }
+      elsif ts.is_a?(ObjectAlbum)
+        add_tracks ts.tracks
+      elsif ts.is_a?(ObjectTrack)
+        tracks << ts
+      else
+        raise "Invalid Object #{ts}"
+      end
+    end
+
+    let(:track_title) { ds.build_field :title }
+
     describe "DataSource factory" do
+      it "should have tracks with album" do
+        expect(tracks).to_not be_empty
+        expect(tracks.first.album).to_not be_nil
+      end
+
       it "should create" do
         expect(ds).to be_a(ObjectDataSource)
+      end
+
+      describe "items" do
+        it "should list all" do
+          expect(ds.items.count).to be(tracks.count)
+        end
+
+        it "should enumerate all items" do
+          expect(begin
+            c = 0
+            ds.items.each do
+              c = c + 1
+            end
+            c
+          end).to be(tracks.count)
+        end
+      end
+
+      describe "paginate" do
+        let(:page_size) { 5 }
+
+        before(:each) { ds.paginate(2, page_size) }
+
+        it "should get only paged items" do
+          expect(ds.items.count).to be(page_size)
+        end
+
+        it "should keep total_count" do
+          expect(ds.items.total_count).to be(tracks.count)
+        end
+      end
+
+      describe "field" do
+        it "should project attribute value" do
+          expect(track_title.value_for(ds.items.first)).to eq(tracks.first.title)
+        end
+
+        it "should navigate and  project attribute value" do
+          expect(album_name.value_for(ds.items.first)).to eq(tracks.first.album.name)
+        end
+      end
+
+      describe "scope" do
+        before(:each) do
+          ds.scope do |items|
+            [].tap do |res|
+              tracks.each_with_index do |item, index|
+                next if index % 2 == 1
+                res << item
+              end
+            end
+          end
+        end
+
+        it "should return scoped items" do
+          expect(ds.items.count).to be(tracks.count / 2)
+        end
+      end
+
+      describe "search" do
+        before(:each) do
+          add_tracks build(:object_album, tracks_count: 5, name: 'album-name-magic-string-1')
+          add_tracks build(:object_album, tracks_count: 5, name: 'album-name-magic-string-2')
+          build_list(:object_album, 2).each do |album_with_tracks_to_match|
+            add_tracks build_list(:object_track, 5, title: 'title-magic-string', album: album_with_tracks_to_match)
+          end
+
+          ds.search([track_title, album_name], 'magic')
+        end
+
+        it "should return matching items" do
+          expect(ds.items.count).to be(20)
+        end
+      end
+
+      describe "filter" do
+        before(:each) do
+          add_tracks build(:object_album, tracks_count: 5, name: 'album-name-magic-string-1')
+          add_tracks build(:object_album, tracks_count: 5, name: 'album-name-magic-string-2')
+
+          ds.filter(album_name, 'album-name-magic-string-1')
+        end
+
+        it "should return matching items" do
+          expect(ds.items.count).to be(5)
+        end
+      end
+
+      describe "sort" do
+        def all_track_albumns_name
+          tracks.map { |t| t.album.name }
+        end
+
+        before(:each) do
+          expect(all_track_albumns_name).to_not eq(all_track_albumns_name.sort)
+          ds.sort(album_name)
+        end
+
+        it "should return matching items" do
+          expect(ds.items.map { |e| album_name.value_for(e) }).to eq(all_track_albumns_name.sort)
+        end
+      end
+
+      describe "sort desc" do
+        def all_track_albumns_name
+          tracks.map { |t| t.album.name }
+        end
+
+        before(:each) do
+          expect(all_track_albumns_name).to_not eq(all_track_albumns_name.sort.reverse)
+          ds.sort(album_name, DataSource::DESC)
+        end
+
+        it "should return matching items" do
+          expect(ds.items.map { |e| album_name.value_for(e) }).to eq(all_track_albumns_name.sort.reverse)
+        end
+      end
+
+      describe "values_for_filter" do
+        let(:tracks) { [] } # skip default test albums
+
+        before(:each) do
+          add_tracks build(:object_album, tracks_count: 5, name: 'album-name-1')
+          add_tracks build(:object_album, tracks_count: 5, name: 'album-name-3')
+          add_tracks build(:object_album, tracks_count: 5, name: 'album-name-2')
+          add_tracks build(:object_album, tracks_count: 5, name: nil)
+        end
+
+        context "without search" do
+          it "should matching values" do
+            expect(ds.values_for_filter(album_name)).to eq(['album-name-1', 'album-name-2', 'album-name-3'])
+          end
+        end
+
+        context "with scope" do
+          before(:each) do
+            ds.scope do |items|
+              [].tap do |res|
+                tracks.each_with_index do |item, index|
+                  next if index % 2 == 1
+                  res << item
+                end
+              end
+            end
+          end
+
+          it "should matching values" do
+            expect(ds.values_for_filter(album_name)).to eq(['album-name-1', 'album-name-2', 'album-name-3'])
+          end
+        end
       end
     end
 
@@ -17,9 +186,31 @@ RSpec.describe ObjectDataSource do
 
   context "using array of objects" do
     let(:ds) { DataSource.for(tracks) }
-    let(:tracks) { [] }
+    let(:album_name) { nil }
 
-    it_behaves_like "object datasource"
+    context "and hash like fields" do
+      let(:album_name) { ds.build_field album: :name }
+      it_behaves_like "object datasource"
+    end
+
+    context "and array like fields" do
+      let(:album_name) { ds.build_field [:album, :name] }
+      it_behaves_like "object datasource"
+    end
   end
 
+  context "using array of hash" do
+    let(:ds) { DataSource.for(tracks.map{ |t| {title: t.title, album: {name: t.album.name } } }) }
+    let(:album_name) { nil }
+
+    context "and hash like fields" do
+      let(:album_name) { ds.build_field album: :name }
+      it_behaves_like "object datasource"
+    end
+
+    context "and array like fields" do
+      let(:album_name) { ds.build_field [:album, :name] }
+      it_behaves_like "object datasource"
+    end
+  end
 end

--- a/spec/lib/sources/object_data_source_spec.rb
+++ b/spec/lib/sources/object_data_source_spec.rb
@@ -36,8 +36,13 @@ RSpec.describe ObjectDataSource do
         before(:each) {
           add_tracks build(:object_track, album: nil)
         }
+
         it "should deal with intermediate nils" do
           expect(album_name.value_for(ds.items.first)).to be_nil
+        end
+
+        it "should have key" do
+          expect(album_name.key).to eq('album_name')
         end
       end
 

--- a/spec/lib/sources/object_data_source_spec.rb
+++ b/spec/lib/sources/object_data_source_spec.rb
@@ -1,0 +1,25 @@
+include Listings::Sources
+
+RSpec.describe ObjectDataSource do
+
+  shared_examples "object datasource" do
+    let(:tracks) {
+      build_list(:object_track, 5)
+    }
+
+    describe "DataSource factory" do
+      it "should create" do
+        expect(ds).to be_a(ObjectDataSource)
+      end
+    end
+
+  end
+
+  context "using array of objects" do
+    let(:ds) { DataSource.for(tracks) }
+    let(:tracks) { [] }
+
+    it_behaves_like "object datasource"
+  end
+
+end

--- a/spec/listings/tracks_fixed_order_listing_spec.rb
+++ b/spec/listings/tracks_fixed_order_listing_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe TracksFixedOrderListing, type: :listing do
+  describe "List entities" do
+    let!(:track) { create(:album, tracks_count: 1) }
+
+    let(:listing) { query_listing :tracks_fixed_order }
+
+    it "should list all" do
+      expect(listing.items.count).to eq(1)
+    end
+
+    it "can be rendered" do
+      render_listing :tracks
+    end
+
+    it "can't be sorted" do
+      expect(listing).to_not be_sortable
+    end
+  end
+end

--- a/spec/listings/tracks_listing_spec.rb
+++ b/spec/listings/tracks_listing_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe TracksListing, type: :listing do
 
     let(:listing) { query_listing :tracks }
 
-    pending "should list all" do
+    it "should list all" do
       expect(listing.items.count).to eq(1)
     end
 
-    pending "can be rendered" do
+    it "can be rendered" do
       render_listing :tracks
     end
   end

--- a/spec/listings/tracks_listing_spec.rb
+++ b/spec/listings/tracks_listing_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe TracksListing, type: :listing do
+  describe "List entities" do
+    let!(:track) { create(:album, tracks_count: 1) }
+
+    let(:listing) { query_listing :tracks }
+
+    it "should list all" do
+      expect(listing.items.count).to eq(1)
+    end
+
+    it "can be rendered" do
+      render_listing :tracks
+    end
+  end
+end

--- a/spec/listings/tracks_listing_spec.rb
+++ b/spec/listings/tracks_listing_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe TracksListing, type: :listing do
 
     let(:listing) { query_listing :tracks }
 
-    it "should list all" do
+    pending "should list all" do
       expect(listing.items.count).to eq(1)
     end
 
-    it "can be rendered" do
+    pending "can be rendered" do
       render_listing :tracks
     end
   end

--- a/spec/listings/tracks_listing_spec.rb
+++ b/spec/listings/tracks_listing_spec.rb
@@ -11,5 +11,17 @@ RSpec.describe TracksListing, type: :listing do
     it "can be rendered" do
       render_listing :tracks
     end
+
+    it "should get name from model" do
+      expect(listing.column_with_key('album_name').human_name).to eq('Album Name')
+    end
+
+    it "should get name from title option for column" do
+      expect(listing.column_with_key('album_id').human_name).to eq('The Album Id')
+    end
+
+    it "should get name from title option for filter" do
+      expect(listing.filter_with_key('album_id').human_name).to eq('The Album Id')
+    end
   end
 end

--- a/spec/models/album_spec.rb
+++ b/spec/models/album_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Album, type: :model do
+  describe "Factory" do
+    it "can create" do
+      create(:album)
+      expect(Album.count).to eq(1)
+      expect(Album.first.tracks.count).to be > 1
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Post, type: :model do
-  describe "Create" do
-    it "can be created" do
+  describe "Factory" do
+    it "can create" do
       create(:post)
       expect(Post.count).to eq(1)
     end

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Track, type: :model do
+  describe "Factory" do
+    it "can create" do
+      create(:track)
+      expect(Track.count).to eq(1)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,9 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/support/query_counter.rb
+++ b/spec/support/query_counter.rb
@@ -1,0 +1,29 @@
+module ActiveRecord
+  class QueryCounter
+    cattr_accessor :query_count do
+      0
+    end
+
+    IGNORED_SQL = [/^PRAGMA (?!(table_info))/, /^SELECT currval/, /^SELECT CAST/, /^SELECT @@IDENTITY/, /^SELECT @@ROWCOUNT/, /^SAVEPOINT/, /^ROLLBACK TO SAVEPOINT/, /^RELEASE SAVEPOINT/, /^SHOW max_identifier_length/]
+
+    def call(name, start, finish, message_id, values)
+      # FIXME: this seems bad. we should probably have a better way to indicate
+      # the query was cached
+      unless 'CACHE' == values[:name]
+        self.class.query_count += 1 unless IGNORED_SQL.any? { |r| values[:sql] =~ r }
+      end
+    end
+  end
+end
+
+ActiveSupport::Notifications.subscribe('sql.active_record', ActiveRecord::QueryCounter.new)
+
+module ActiveRecord
+  class Base
+    def self.count_queries(&block)
+      ActiveRecord::QueryCounter.query_count = 0
+      yield
+      ActiveRecord::QueryCounter.query_count
+    end
+  end
+end


### PR DESCRIPTION
- Refactor listings. 
- Split logic to access datasources form listings dsl.
- Support for belongs_to assocation in active_record models.
- Improve sort, search, filter on fields, relations and plain objects.
- Remove `column :name, sortable: 'expr'` support since now it is supported in a cleaner way. `column :expr, title: 'name`
